### PR TITLE
Add cmds for linux user to run in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,13 @@ RUN ls -l
 RUN go mod download
 RUN go mod tidy
 
+# Linux version
+# RUN groupadd -r myuser && useradd -r -g myuser -G audio,video myuser \
+#     && mkdir -p /home/myuser/Downloads \
+#     && chown -R myuser:myuser /home/myuser
+
+# USER myuser
+
 USER chrome
 
 # Autorun chrome


### PR DESCRIPTION
The original Dockerfile occurred an error when ran, because the user 'chrome' does not exist, as a result, I updated the script with commented format to create a normal user on every run.